### PR TITLE
Unique ID clash with 'teste'

### DIFF
--- a/src/sequence-viewer.js
+++ b/src/sequence-viewer.js
@@ -62,7 +62,7 @@ var Sequence = (function () {
                 "<div class=\"sequenceBody\" style=\"margin-top: 5px;\">" +
                 "<div class=\"scroller\" style=\"max-height:" + seqHeight + ";overflow:auto;white-space: nowrap;padding-right:20px;margin-right:10px;s\">" +
                 "<div class=\"charNumbers\" style=\"font-family: monospace;font-size: 13px;display:inline-block;text-align:right; padding-right:5px; border-right:1px solid LightGray;\"></div>" +
-                "<div id='teste' class=\"fastaSeq\" display-option=\"" + lineJump + "\" style=\"font-family: monospace;font-size: 13px;display:inline-block;padding:5px;\">{{{sequence}}}</div></div>" +
+                "<div class=\"fastaSeq\" display-option=\"" + lineJump + "\" style=\"font-family: monospace;font-size: 13px;display:inline-block;padding:5px;\">{{{sequence}}}</div></div>" +
                 "<div class=\"coverageLegend\" style=\"margin-top: 10px;margin-left:15px;\"></div>" +
                 "</div>";
 


### PR DESCRIPTION
I removed the 'teste' ID from a div in the 'sources' variable.  Otherwise, using the component more than once in a page produces div elements with non unique IDs.  I didn't see any place that it was currently being used and all unit tests still pass.  Removing it seemed like the best course of action.